### PR TITLE
Fix: Last song in MODList not being played in arcarde mode

### DIFF
--- a/src/org/jfedor/frozenbubble/FrozenBubble.java
+++ b/src/org/jfedor/frozenbubble/FrozenBubble.java
@@ -939,7 +939,7 @@ public class FrozenBubble extends Activity
     else
     {
       Random rand = new Random();
-      modNow = rand.nextInt(MODlist.length - 1);
+      modNow = rand.nextInt(MODlist.length);
     }
     /*
      * Determine whether to create a music player or load the song.


### PR DESCRIPTION
While playing FrozenBubble on my phone I noticed that there is a song (technostyleiii) from the background "soundtrack" which is being played during puzzle mode but not during arcarde mode. After looking at the code I found out that this is caused by an off-by-one-error in the number range which is submitted to the Random class to select a random new track. This caused that the last song in the MODList array is never selected during random play.